### PR TITLE
修改设置字段默认值时的策略

### DIFF
--- a/examples/schemaBuilder.php
+++ b/examples/schemaBuilder.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author: RunnerLee
+ * @email: runnerleer@gmail.com
+ * @time: 16-7-1 下午4:47
+ */
+require __DIR__ . '/../vendor/autoload.php';
+
+$table = new \FastD\Database\Schema\Structure\Table('demo');
+
+$id = (new \FastD\Database\Schema\Structure\Field('id', \FastD\Database\Schema\Structure\Field::INT, 11))
+        ->setIncrement()->setUnsigned(true);
+
+$username = new \FastD\Database\Schema\Structure\Field('username', \FastD\Database\Schema\Structure\Field::VARCHAR, 255);
+
+$primaryKey = new \FastD\Database\Schema\Structure\Key(\FastD\Database\Schema\Structure\Key::PRIMARY);
+
+$table->addField($id, $primaryKey);
+
+$table->addField($username);
+
+$schemaBuilder = new \FastD\Database\Schema\SchemaBuilder();
+$schemaBuilder->addTable($table);
+
+echo "\n";
+echo $schemaBuilder->update();
+echo "\n";

--- a/src/Database/Schema/SchemaBuilder.php
+++ b/src/Database/Schema/SchemaBuilder.php
@@ -58,7 +58,7 @@ class SchemaBuilder extends Schema
                 $field->getType() . '(' . $field->getLength() . ')',
                 ($field->isUnsigned()) ? 'UNSIGNED' : '',
                 ($field->isNullable() ? '' : ('NOT NULL')),
-                (!$field->isIncrement() ? 'DEFAULT "' . $field->getDefault() . '"' : '') ,
+                (!$field->isIncrement() && !$field->isUnique() && !$field->isPrimary() ? 'DEFAULT "' . $field->getDefault() . '"' : '') ,
                 ($field->isIncrement()) ? 'AUTO_INCREMENT' : '',
                 'COMMENT "' . $field->getComment() . '"'
             ]);
@@ -111,7 +111,7 @@ class SchemaBuilder extends Schema
                 $field->getType() . '(' . $field->getLength() . ')',
                 ($field->isUnsigned()) ? 'UNSIGNED' : '',
                 ($field->isNullable() ? '' : ('NOT NULL')),
-                ((!empty($field->getDefault()) && !$field->isIncrement()) ? 'DEFAULT "' . $field->getDefault() . '"' : '') ,
+                ((!empty($field->getDefault()) && !$field->isIncrement() && !$field->isUnique() && !$field->isPrimary()) ? 'DEFAULT "' . $field->getDefault() . '"' : '') ,
                 ($field->isPrimary()) ? 'AUTO_INCREMENT' : '',
                 'COMMENT "' . $field->getComment() . '";',
             ]);
@@ -133,7 +133,8 @@ class SchemaBuilder extends Schema
                         'ALTER TABLE `' . $this->getCurrentTable()->getFullTableName() . '` CHANGE `' . $name . '` `' . $field->getName() . '`',
                         $field->getType() . '(' . $field->getLength() . ')',
                         ($field->isUnsigned()) ? 'UNSIGNED' : '',
-                        ($field->isNullable() ? '' : ('NOT NULL DEFAULT "' . $field->getDefault() . '"')),
+                        ($field->isNullable() ? '' : ('NOT NULL')),
+                        ((!empty($field->getDefault()) && !$field->isIncrement() && !$field->isUnique() && !$field->isPrimary()) ? 'DEFAULT "' . $field->getDefault() . '"' : '') ,
                         ($field->isPrimary()) ? 'AUTO_INCREMENT' : '',
                         'COMMENT "' . $field->getComment() . '";',
                     ]);

--- a/src/Database/Tests/Schema/SchemaBuilderTest.php
+++ b/src/Database/Tests/Schema/SchemaBuilderTest.php
@@ -28,7 +28,7 @@ class SchemaBuilderTest extends \PHPUnit_Framework_TestCase
 
         $testTable = new Table('test');
 
-        $testTable->addField(new Field('id', Field::INT, 10));
+        $testTable->addField(new Field('id', Field::INT, 10), new Key(Key::PRIMARY));
 
         $builder->addTable($testTable);
 
@@ -37,7 +37,7 @@ class SchemaBuilderTest extends \PHPUnit_Framework_TestCase
         if (!$builder->hasCacheField()) {
             $this->assertEquals(<<<EOF
 CREATE TABLE `test` (
-`id` int(10)  NOT NULL DEFAULT "0"  COMMENT ""
+`id` int(10) UNSIGNED NOT NULL   COMMENT ""
 ) ENGINE InnoDB CHARSET utf8 COMMENT "";
 EOF
             , $schema);


### PR DESCRIPTION
当字段为自动增长，或者有唯一/主键 索引时，不允许设置默认值。